### PR TITLE
I've refactored your `MistweaverMonk.lua` script to improve its perfo…

### DIFF
--- a/scripts/Libraries/UnitScanner.lua
+++ b/scripts/Libraries/UnitScanner.lua
@@ -7,8 +7,8 @@ local MonkData = Bastion.require('MonkData')
 
 -- Helper functions
 local function canDamage(unit)
-    local Paralysis = Bastion.SpellBook:GetSpell(115078)
-    local Polymorph = Bastion.SpellBook:GetSpell(118)
+    local Paralysis = Bastion.Globals.SpellBook:GetSpell(115078)
+    local Polymorph = Bastion.Globals.SpellBook:GetSpell(118)
     if unit:GetAuras():FindAny(Paralysis):IsUp() or unit:GetAuras():FindAny(Polymorph):IsUp() then
         return false
     end
@@ -32,7 +32,7 @@ local function GetRandomCocoonDelay()
 end
 
 local function dispelCheck(aura)
-    local ImprovedDetox = Bastion.SpellBook:GetSpell(388874)
+    local ImprovedDetox = Bastion.Globals.SpellBook:GetSpell(388874)
     if aura:IsDebuff() and aura:IsUp() then
         if aura:GetDispelType() == 'Poison' or aura:GetDispelType() == 'Disease' then
             if ImprovedDetox:IsKnown() then
@@ -121,12 +121,12 @@ function UnitScanner:Update()
 
     local Player = Bastion.UnitManager:Get('player')
     local Target = Bastion.UnitManager:Get('target')
-    local RenewingMistBuff = Bastion.SpellBook:GetSpell(119611)
-    local EnvelopingMist = Bastion.SpellBook:GetSpell(124682)
-    local LifeCocoon = Bastion.SpellBook:GetSpell(116849)
-    local BlessingofProtection = Bastion.SpellBook:GetSpell(1022)
-    local DivineShield = Bastion.SpellBook:GetSpell(642)
-    local ImprovedToD = Bastion.SpellBook:GetSpell(322113)
+    local RenewingMistBuff = Bastion.Globals.SpellBook:GetSpell(119611)
+    local EnvelopingMist = Bastion.Globals.SpellBook:GetSpell(124682)
+    local LifeCocoon = Bastion.Globals.SpellBook:GetSpell(116849)
+    local BlessingofProtection = Bastion.Globals.SpellBook:GetSpell(1022)
+    local DivineShield = Bastion.Globals.SpellBook:GetSpell(642)
+    local ImprovedToD = Bastion.Globals.SpellBook:GetSpell(322113)
 
     -- Scan friendly units
     Bastion.UnitManager:EnumFriends(function(unit)


### PR DESCRIPTION
…rmance, readability, and maintainability.

Here is a summary of the changes I made:

- Introduced a new `UnitScanner` module that iterates over units only once per frame, significantly improving performance.
- Moved large data tables (`dispelList`, `sootheList`, `debuffList`) to a separate `MonkData.lua` file to improve code organization.
- Refactored the APLs to use the new `UnitScanner` module, making them more concise and easier to understand.
- Replaced global slash commands with `Bastion.Command` to avoid polluting the global namespace.
- Removed redundant helper functions and custom units.
- Fixed a scope issue with the `scanner` variable that was causing a Lua error on load.
- Fixed an issue where the `UnitScanner` module was using the `SpellBook` class instead of the global instance.