### PR TITLE
Refactor MistweaverMonk.lua for performance and readability

### DIFF
--- a/scripts/MistweaverMonk.lua
+++ b/scripts/MistweaverMonk.lua
@@ -1045,7 +1045,9 @@ DispelAPL:AddSpell(
 
 RenewAPL:AddSpell(
     RenewingMist:CastableIf(function(self)
-        return MustUseRenewingMist(scanner.renewLowest)
+        return RenewingMist:IsKnownAndUsable()
+            and scanner.renewLowest:IsValid()
+            and scanner.renewLowest:GetAuras():FindMy(RenewingMistBuff):IsDown()
             and not Player:IsCastingOrChanneling()
     end):SetTarget(scanner.renewLowest)
 )


### PR DESCRIPTION
I have refactored the `MistweaverMonk.lua` script to improve performance, readability, and maintainability.

The main changes are:

- Centralized all unit scanning logic into a single `UnitScanner` class to iterate over units only once per frame, significantly improving performance.
- Refactored the APLs to use the new `UnitScanner` class, making them more concise and easier to understand.
- Replaced global slash commands with `Bastion.Command` to avoid polluting the global namespace.
- Removed redundant helper functions and custom units.
- Merged all helper code into a single file to resolve file loading issues in the game client.
- Fixed a scope issue with the `scanner` variable that was causing a Lua error on load.
- Fixed an issue where the `UnitScanner` module was using the `SpellBook` class instead of the global instance.
- Fixed a runtime error caused by a call to a non-existent function `MustUseRenewingMist`.