### PR TITLE
fix: Refine buster targeting logic

### DIFF
--- a/scripts/MistweaverMonk.lua
+++ b/scripts/MistweaverMonk.lua
@@ -799,15 +799,11 @@ local function scanEnemies()
         end
 
         -- Buster Target Logic
-        if unit:IsCasting() and not unit:IsInterruptible() and MythicPlusUtils:CastingCriticalBusters(unit) then
+        if unit:IsCastingOrChanneling() and not unit:IsInterruptible() and MythicPlusUtils:CastingCriticalBusters(unit) then
             if not cachedUnits.busterTarget then -- Only need one
                 local castTarget = Bastion.UnitManager:Get(ObjectCastingTarget(unit:GetOMToken()))
                 if castTarget and Player:GetDistance(castTarget) <= 40 and Player:CanSee(castTarget) and castTarget:IsAlive() then
                     cachedUnits.busterTarget = castTarget
-                elseif cachedUnits.tankTarget and cachedUnits.tankTarget:IsTanking(unit) and Player:GetDistance(cachedUnits.tankTarget) <= 40 and Player:CanSee(cachedUnits.tankTarget) and cachedUnits.tankTarget:IsAlive() then
-                    cachedUnits.busterTarget = cachedUnits.tankTarget
-                else
-                    cachedUnits.busterTarget = cachedUnits.tankTarget2 or cachedUnits.tankTarget
                 end
             end
         end


### PR DESCRIPTION
This commit refines the targeting logic for tank busters based on your feedback.

- Changed `unit:IsCasting()` to the more comprehensive `unit:IsCastingOrChanneling()` to correctly identify channeled buster abilities.
- Simplified the target assignment to only consider the explicit cast target of the ability. The previous fallback logic that assigned the current tank has been removed for precision.