### PR TITLE
refactor(apl): Remove redundant charge check for TFT buster cast

### DIFF
--- a/scripts/MistweaverMonk.lua
+++ b/scripts/MistweaverMonk.lua
@@ -1350,7 +1350,6 @@ DefensiveAPL:AddSpell(
     ThunderFocusTea:CastableIf(function(self)
         return self:IsKnownAndUsable() and Player:GetAuras():FindMy(ThunderFocusTea):IsDown()
             and BusterTargetTFT:IsValid() and ShouldUseEnvelopingMist(BusterTargetTFT)
-            and self:GetCharges() >= 2
     end):SetTarget(Player):OnCast(function()
         EnvelopingMist:Cast(BusterTargetTFT)
     end)


### PR DESCRIPTION
This commit removes a redundant check for Thunder Focus Tea charges from the Defensive APL.

The `BusterTargetTFT` custom unit is only populated when TFT has sufficient charges available. Therefore, checking for charges again within the APL's `CastableIf` condition was unnecessary.

This change simplifies the logic and makes the code slightly more efficient.