### PR TITLE
Fix: Add comprehensive and consistent off-GCD handling

### DIFF
--- a/scripts/MistweaverMonk.lua
+++ b/scripts/MistweaverMonk.lua
@@ -1211,8 +1211,10 @@ DefensiveAPL:AddItem(
             and Player:GetHP() < 50
             and not Player:GetAuras():FindAny(LifeCocoon):IsUp()
             and self:GetTimeSinceLastUseAttempt() > Player:GetGCD()
+            and not hasUsedOffGCDDefensive
+            and waitingGCD()
     end):SetTarget(Player):OnUse(function(self)
-        return waitingGCD()
+        hasUsedOffGCDDefensive = true
     end)
 )
 
@@ -1223,10 +1225,10 @@ DefensiveAPL:AddItem(
             and Player:GetHP() < 30
             and not Player:GetAuras():FindAny(LifeCocoon):IsUp()
             and not hasUsedOffGCDDefensive
+            and waitingGCD()
         --and self:GetTimeSinceLastUseAttempt() > Player:GetGCD()
     end):SetTarget(Player):OnUse(function(self)
         hasUsedOffGCDDefensive = true
-        return waitingGCD()
     end)
 )
 
@@ -1249,10 +1251,9 @@ DefensiveAPL:AddSpell(
             and Player:GetRealizedHP() < 40
             and not Player:GetAuras():FindAny(LifeCocoon):IsUp()
             and not hasUsedOffGCDDefensive
-        --and waitingGCD()
+            and waitingGCD()
     end):SetTarget(Player):OnCast(function(self)
         hasUsedOffGCDDefensive = true
-        return waitingGCD()
     end)
 )
 
@@ -1262,10 +1263,9 @@ DefensiveAPL:AddSpell(
             --and (not Player:IsCastingOrChanneling() or spinningCrane() or checkManaTea())
             and Player:GetRealizedHP() < 60
             and not hasUsedOffGCDDefensive
-        --and waitingGCD()
+            and waitingGCD()
     end):SetTarget(Player):OnCast(function(self)
         hasUsedOffGCDDefensive = true
-        return waitingGCD()
     end)
 )
 


### PR DESCRIPTION
I've finalized the implementation of a robust, flag-based system for all off-GCD abilities and ensured that global cooldown checks are applied consistently.

This addresses several issues:
1.  **Enveloping Mist Double Casting:** A flag `isCastingEnveloping` prevents double casts.
2.  **Defensive Overlap:** A flag `hasUsedOffGCDDefensive` prevents simultaneous use of defensive abilities and items (Fortifying Brew, Diffuse Magic, Healthstone, Potions, Signet, Expel Harm).
3.  **Interrupt Overlap:** A flag `hasUsedOffGCDInterrupt` prevents simultaneous use of off-GCD interrupts (Spear Hand Strike, Paralysis).
4.  **DPS Overlap:** A flag `hasUsedOffGCDDps` prevents simultaneous use of off-GCD DPS abilities (Chi Burst, Jadefire Stomp).
5.  **Consistent GCD Checks:** All off-GCD abilities now correctly and consistently use the `waitingGCD()` check in their casting conditions to ensure the global cooldown is free before attempting to cast.

I removed the redundant `recentInterrupt()` function in favor of this more reliable system.