### PR TITLE
Fix(MistweaverMonk): Remove JadefireStomp condition from ChiBurst

### DIFF
--- a/scripts/MistweaverMonk.lua
+++ b/scripts/MistweaverMonk.lua
@@ -1448,7 +1448,6 @@ StompAPL:AddSpell(
 DpsAPL:AddSpell(
     ChiBurst:CastableIf(function(self)
         return self:IsKnownAndUsable() and not Player:IsCastingOrChanneling()
-            and not JadefireStomp:IsKnownAndUsable() --and Player:GetEnemies(10) >= 1
             --and (Player:IsWithinCone(rangeTarget,90,40) or Player:IsWithinCone(nearTarget,90,40) or Player:IsWithinCone(TankTarget,90,40))
             and not Player:IsMoving()
             and not stopCasting()


### PR DESCRIPTION
This commit removes the condition that prevented Chi Burst from being cast when Jadefire Stomp is known and usable. This allows for more flexible use of Chi Burst in the rotation.