### PR TITLE
Feat: Add spell queue logic for faster and more accurate casting

### DIFF
--- a/scripts/MistweaverMonk.lua
+++ b/scripts/MistweaverMonk.lua
@@ -106,13 +106,6 @@ local hasUsedOffGCDDps = false
 
 -- Add this helper function near the top of the file, after the SpellBook initialization
 
-local function waitingGCD()
-    return Player:GetGCD() * 1000 < (select(4, GetNetStats()) and select(3, GetNetStats()))
-end
-local function waitingGCDcast(spell)
-    return spell:GetTimeSinceLastCastAttempt() > Player:GetGCD()
-end
-
 local function GetRandomInterruptDelay()
     return math.random(40, 60)
 end
@@ -666,7 +659,6 @@ end
 local function ShouldUseCrackling(unit)
     return CracklingJadeLightning:IsKnownAndUsable() and unit:IsValid() and canDamage(unit) and not Player:IsMoving()
         --and CracklingJadeLightning:GetTimeSinceLastCastAttempt() > 2
-        and waitingGCDcast(CracklingJadeLightning)
         and Player:GetAuras():FindMy(JadeEmpowerment):IsUp()
         and not Player:IsCastingOrChanneling()
         and not stopCasting()
@@ -1383,7 +1375,6 @@ CooldownAPL:AddSpell(
             and not stopCasting()
             and ThunderFocusTea:GetCharges() < 1
             and Player:GetAuras():FindMy(ThunderFocusTea):IsDown()
-            and waitingGCD()
     end):SetTarget(EnvelopeLowest)
     -- :PreCast(function()
     --     --UpdateManaTeaStacks()
@@ -1650,7 +1641,6 @@ StompAPL:AddSpell(
             --and not (Player:GetAuras():FindMy(JadefireTeachingsBuff):GetRemainingTime() > 2) and InMelee(nearTarget)
             and Target:IsValid()
             --and Player:IsWithinCone(TankTarget,90,40)
-            and waitingGCD()
             and not hasUsedOffGCDDps
     end):SetTarget(Player):OnCast(function()
         hasUsedOffGCDDps = true
@@ -1722,7 +1712,6 @@ DpsAPL:AddSpell(
             --and (Player:IsWithinCone(rangeTarget,90,40) or Player:IsWithinCone(Target,90,40) or Player:IsWithinCone(TankTarget,90,40))
             and not Player:IsMoving()
             and not stopCasting()
-            and waitingGCD()
             and mostEnemies():IsValid()
             and not hasUsedOffGCDDps
     end):SetTarget(Player):OnCast(function()


### PR DESCRIPTION
This change introduces a new spell queuing mechanism to improve casting speed and accuracy.

- A new function `GetSpellQueueWindow` has been added to `src/Spell/Spell.lua` to calculate the effective spell queue window based on network latency.
- The `Spell:Cast` function in `src/Spell/Spell.lua` has been updated to use this function, allowing spells to be queued up just before the current cast finishes.
- The `SpellCancelQueuedSpell()` function has been removed from `Spell:Cast` and `Spell:ForceCast` to enable spell queuing.
- Redundant GCD-based timing checks (`waitingGCD` and `waitingGCDcast`) have been removed from `scripts/MistweaverMonk.lua` as they are now handled by the new generic spell queuing logic.