### PR TITLE
Fix: Correct stopCasting logic and improve casting system

### DIFF
--- a/scripts/MistweaverMonk.lua
+++ b/scripts/MistweaverMonk.lua
@@ -597,17 +597,20 @@ _G.SlashCmdList['INTERRALL'] = function(msg)
 end
 -- Stopcasting
 local function stopCasting()
+    local shouldStop = false
     Bastion.UnitManager:EnumEnemies(function(unit)
+        if shouldStop then return end
+
         if unit:IsDead() or not Player:IsWithinDistance(unit, 40) or not Player:CanSee(unit) or not unit:IsCastingOrChanneling() then
-            return false
+            return
         end
-        if stopcastList[unit:GetCastingOrChannelingSpell():GetID()] then
-            --if unit:GetCastingOrChannelingEndTime() - GetTime() < 2 then
-            return true
-            --end
+
+        local spell = unit:GetCastingOrChannelingSpell()
+        if spell and stopcastList[spell:GetID()] then
+            shouldStop = true
         end
     end)
-    return false
+    return shouldStop
 end
 -- Helper Functions
 local function ShouldUseRenewingMist(unit)


### PR DESCRIPTION
This change fixes a bug in the `stopCasting` function and also includes the previously developed improvements to the casting system.

- The `stopCasting` function in `scripts/MistweaverMonk.lua` has been fixed to correctly return `true` when an enemy is casting a spell from the `stopcastList`.
- A new helper module `Casting.lua` has been created to centralize casting-related logic, including `GetSpellQueueWindow` and `PlayerIsBusy` functions.
- The `GetSpellQueueWindow` function now includes a random delay of 10-50ms to simulate a human player.
- The `PlayerIsBusy` function correctly checks if the player is currently casting a spell or on the Global Cooldown (GCD), taking the spell queue window into account.
- The `Spell` and `Item` classes have been updated to use the new `Casting` module.
- A new property `isOffGCD` and associated methods have been added to both `Spell` and `Item` classes to allow them to be marked as off-GCD.
- The casting and usage logic now correctly handles off-GCD spells and items, allowing them to be used even when the player is on the GCD.
- The `Spell` class has a new `interruptsCast` property and methods. If this flag is set, `SpellStopCasting()` is called before the spell is cast, ensuring time-critical interrupts are not delayed by another cast.
- The `scripts/MistweaverMonk.lua` file has been updated to correctly mark spells and items with the new `isOffGCD` and `interruptsCast` flags.