### PR TITLE
Feat: Overhaul casting logic for spells and items

### DIFF
--- a/scripts/MistweaverMonk.lua
+++ b/scripts/MistweaverMonk.lua
@@ -79,8 +79,8 @@ local PotentialEnergy = SpellBook:GetSpell(1239483)
 local Polymorph = SpellBook:GetSpell(118)
 
 -- Items
-local Healthstone = ItemBook:GetItem(5512):SetOffGCD(true)
-local AlgariHealingPotion = ItemBook:GetItem(211880):SetOffGCD(true)
+local Healthstone = ItemBook:GetItem(5512):SetOffGCD(true):SetInterruptsCast(true)
+local AlgariHealingPotion = ItemBook:GetItem(211880):SetOffGCD(true):SetInterruptsCast(true)
 local Noggen = ItemBook:GetItem(232486)
 local KoD = ItemBook:GetItem(215174)    -- Kiss of Death
 local Signet = ItemBook:GetItem(219308) -- Signet of Priory

--- a/src/Item/Item.lua
+++ b/src/Item/Item.lua
@@ -13,6 +13,7 @@ local Item = {
     conditions = {},
     target = false,
     isOffGCD = false,
+    interruptsCast = false,
 }
 
 local usableExcludes = {
@@ -146,6 +147,10 @@ function Item:Use(unit, condition)
 
     if not self:IsOffGCD() and Casting:PlayerIsBusy() then
         return false
+    end
+
+    if self:InterruptsCast() then
+        SpellStopCasting()
     end
 
     -- Call pre Use function
@@ -441,6 +446,15 @@ end
 
 function Item:IsOffGCD()
     return self.isOffGCD
+end
+
+function Item:SetInterruptsCast(interrupts_cast)
+    self.interruptsCast = interrupts_cast
+    return self
+end
+
+function Item:InterruptsCast()
+    return self.interruptsCast
 end
 
 -- IsMagicDispel


### PR DESCRIPTION
This change introduces a new, robust casting system that improves casting speed and accuracy by implementing spell queuing, while also correctly handling off-GCD spells, items, and interrupts. It also fixes a bug in the `stopCasting` function.

- A new helper module `Casting.lua` has been created to centralize casting-related logic, including `GetSpellQueueWindow` and `PlayerIsBusy` functions.
- The `GetSpellQueueWindow` function now includes a random delay of 10-50ms to simulate a human player.
- The `PlayerIsBusy` function correctly checks if the player is currently casting a spell or on the Global Cooldown (GCD), taking the spell queue window into account.
- The `Spell` and `Item` classes have been updated to use the new `Casting` module.
- New properties `isOffGCD` and `interruptsCast` and associated methods have been added to both `Spell` and `Item` classes to allow them to be marked as off-GCD and/or as interrupting the current cast.
- The casting and usage logic now correctly handles these flags, allowing for more precise control over casting behavior.
- The `scripts/MistweaverMonk.lua` file has been updated to correctly mark spells and items with the new `isOffGCD` and `interruptsCast` flags.
- A bug in the `stopCasting` function in `scripts/MistweaverMonk.lua` has been fixed to correctly return `true` when an enemy is casting a dangerous spell.