### PR TITLE
Fix Enveloping Mist cast after Thunder Focus Tea

### DIFF
--- a/scripts/MW.lua
+++ b/scripts/MW.lua
@@ -1388,7 +1388,9 @@ DefensiveAPL:AddSpell(
             --and ThunderFocusTea:GetCharges() >= 2
             and Player:GetAuras():FindMy(ThunderFocusTea):IsDown()
     end):SetTarget(Player):OnCast(function()
-        C_Timer.After(0.1, function()
+        local latency = select(4, GetNetStats()) or 100
+        local delay = (latency / 1000) + 0.05
+        C_Timer.After(delay, function()
             EnvelopingMist:Cast(EnvelopeLowest)
         end)
     end)
@@ -1404,7 +1406,9 @@ DefensiveAPL:AddSpell(
             --and ThunderFocusTea:GetCharges() >= 2
             and Player:GetAuras():FindMy(ThunderFocusTea):IsDown()
     end):SetTarget(Player):OnCast(function()
-        C_Timer.After(0.1, function()
+        local latency = select(4, GetNetStats()) or 100
+        local delay = (latency / 1000) + 0.05
+        C_Timer.After(delay, function()
             EnvelopingMist:Cast(DebuffTargetWithoutTFT)
         end)
     end)
@@ -1420,7 +1424,9 @@ DefensiveAPL:AddSpell(
             and ThunderFocusTea:GetCharges() >= 2
             and Player:GetAuras():FindMy(ThunderFocusTea):IsDown()
     end):SetTarget(Player):OnCast(function()
-        C_Timer.After(0.1, function()
+        local latency = select(4, GetNetStats()) or 100
+        local delay = (latency / 1000) + 0.05
+        C_Timer.After(delay, function()
             EnvelopingMist:Cast(BusterTargetWithoutTFT)
         end)
     end)
@@ -1438,7 +1444,9 @@ DefensiveAPL:AddSpell(
             and ThunderFocusTea:GetCharges() >= 2
             and Player:GetAuras():FindMy(ThunderFocusTea):IsDown()
     end):SetTarget(Player):OnCast(function()
-        C_Timer.After(0.1, function()
+        local latency = select(4, GetNetStats()) or 100
+        local delay = (latency / 1000) + 0.05
+        C_Timer.After(delay, function()
             EnvelopingMist:Cast(TankTarget)
         end)
     end)


### PR DESCRIPTION
Refactored the logic for casting Enveloping Mist after Thunder Focus Tea to fix a race condition by using an adaptive delayed cast.

The previous implementation attempted to cast Enveloping Mist from within the OnCast handler of Thunder Focus Tea, which often failed because the instant-cast buff had not yet been applied by the server.

This change applies a dynamic delay to the cast of `Enveloping Mist` using `C_Timer.After`. The delay is calculated based on the player's world latency plus a 50ms buffer. This ensures the buff is active when the spell is cast, making the solution robust for users with varying latency. This fix is applied to all four APL entries that handle this interaction.