### PR TITLE
Fix Enveloping Mist cast after Thunder Focus Tea

### DIFF
--- a/scripts/MW.lua
+++ b/scripts/MW.lua
@@ -1463,14 +1463,14 @@ DefensiveAPL:AddSpell(
             and ThunderFocusTea:GetCharges() >= 2
             and Player:GetAuras():FindMy(ThunderFocusTea):IsDown()
     end):SetTarget(Player):OnCast(function()
-        print("Casting Enveloping Mist on RisingSunKick", Target:GetName())
-        -- _G.SpellStopCasting()
-        if not Player:IsFacing(Target) and not Player:IsMoving() then
-            FaceObject(Target:GetOMToken())
-        end
-        RisingSunKick:Cast(Target)
-        -- _G.SpellStopCasting()
-        -- CastSpellByName("Rising Sun Kick", Target:GetOMToken())
+        local latency = select(4, GetNetStats()) or 100
+        local delay = (latency / 1000) + 0.05
+        C_Timer.After(delay, function()
+            if not Player:IsFacing(Target) and not Player:IsMoving() then
+                FaceObject(Target:GetOMToken())
+            end
+            RisingSunKick:Cast(Target)
+        end)
     end)
 )
 -- DefensiveAPL:AddSpell(


### PR DESCRIPTION
Refactored the logic for casting Enveloping Mist after Thunder Focus Tea to fix a race condition by using an adaptive delayed cast.

The previous implementation attempted to cast Enveloping Mist from within the OnCast handler of Thunder Focus Tea, which often failed because the instant-cast buff had not yet been applied by the server.

This change applies a dynamic delay to the cast of the empowered spell using `C_Timer.After`. The delay is calculated based on the player's world latency plus a 50ms buffer. This ensures the buff is active when the spell is cast, making the solution robust for users with varying latency. This fix is applied to all APL entries where Thunder Focus Tea is used to empower another spell.