### PR TITLE
feat: Add method to identify last spell casted

### DIFF
--- a/src/LastSpell/LastSpell.lua
+++ b/src/LastSpell/LastSpell.lua
@@ -1,0 +1,31 @@
+local Tinkr, Bastion = ...
+
+---@class LastSpell
+local LastSpell = {
+    spell = false,
+    castedAt = false
+}
+
+--- Set the last spell casted
+---@param spell Spell
+function LastSpell:Set(spell)
+    self.spell = spell
+    self.castedAt = GetTime()
+end
+
+--- Get the last spell casted
+---@return Spell
+function LastSpell:Get()
+    return self.spell
+end
+
+--- Get the time since the last spell was casted
+---@return number
+function LastSpell:GetTimeSince()
+    if not self.castedAt then
+        return math.huge
+    end
+    return GetTime() - self.castedAt
+end
+
+return LastSpell

--- a/src/_bastion.lua
+++ b/src/_bastion.lua
@@ -94,6 +94,8 @@ function Bastion.Bootstrap()
     Bastion.ObjectManager = Bastion.require("ObjectManager"):New()
     ---@type EventManager
     Bastion.EventManager = Bastion.require("EventManager")
+    ---@type LastSpell
+    Bastion.LastSpell = Bastion.require('LastSpell')
     Bastion.Globals.EventManager = Bastion.EventManager:New()
     ---@type Spell
     Bastion.Spell = Bastion.require("Spell")
@@ -138,6 +140,7 @@ function Bastion.Bootstrap()
 
         if unit == "player" and spell then
             spell.lastCastAt = GetTime()
+            Bastion.LastSpell:Set(spell)
 
             if spell:GetPostCastFunction() then
                 spell:GetPostCastFunction()(spell)


### PR DESCRIPTION
Introduces a new `LastSpell` module to track the last spell cast by the player. This module provides a centralized way to access the last spell that was successfully cast.

The `LastSpell` module includes the following methods:
- `Set(spell)`: Sets the last casted spell.
- `Get()`: Retrieves the last casted spell.
- `GetTimeSince()`: Gets the time since the last spell was cast.

The `UNIT_SPELLCAST_SUCCEEDED` event handler in `_bastion.lua` is updated to call `LastSpell:Set(spell)` whenever a spell is successfully cast, ensuring the module is always up-to-date.