### PR TITLE
fix: Add charge condition for Thunder Focus Tea

### DIFF
--- a/scripts/MW.lua
+++ b/scripts/MW.lua
@@ -1402,11 +1402,11 @@ DefensiveAPL:AddSpell(
     ThunderFocusTea:CastableIf(function(self)
         local target = EnvelopeLowest or DebuffTargetWithoutTFT or BusterTargetWithoutTFT or TankTarget
         local rskTarget = Target
-        local shouldUseForEnveloping = target:IsValid() and ShouldUseEnvelopingMist(target)
-        local shouldUseForRisingSunKick = rskTarget:IsValid() and RisingSunKick:IsKnownAndUsable() and Player:GetAuras():FindMy(JadefireTeachingsBuff):IsUp() and HarmonyMax()
+
+        local shouldUseForEnveloping = self:GetCharges() >= 1 and target:IsValid() and ShouldUseEnvelopingMist(target)
+        local shouldUseForRisingSunKick = self:GetCharges() >= 2 and rskTarget:IsValid() and RisingSunKick:IsKnownAndUsable() and Player:GetAuras():FindMy(JadefireTeachingsBuff):IsUp() and HarmonyMax()
 
         return self:IsKnownAndUsable()
-            and self:GetCharges() > 0
             and Player:GetAuras():FindMy(ThunderFocusTea):IsDown()
             and (shouldUseForEnveloping or shouldUseForRisingSunKick)
     end):SetTarget(Player)


### PR DESCRIPTION
This change modifies the casting logic for Thunder Focus Tea in the DefensiveAPL.

- When considered for use with Rising Sun Kick, Thunder Focus Tea now requires >= 2 charges.
- When considered for use with Enveloping Mist, it still only requires >= 1 charge.

This ensures that the more powerful combination is only used when sufficient charges are available.