### PR TITLE
fix: Prevent spell queue race condition with Thunder Focus Tea

### DIFF
--- a/src/Spell/Spell.lua
+++ b/src/Spell/Spell.lua
@@ -240,9 +240,7 @@ function Spell:Cast(unit, condition)
 
     -- Cast the spell
     CastSpellByName(self:GetName(), u)
-    if self:GetID() ~= 116680 then
-        SpellCancelQueuedSpell()
-    end
+    SpellCancelQueuedSpell()
 
     Bastion:Debug("Casting", self)
 
@@ -278,9 +276,7 @@ function Spell:ForceCast(unit)
 
     -- Cast the spell
     CastSpellByName(self:GetName(), u)
-    if self:GetID() ~= 116680 then
-        SpellCancelQueuedSpell()
-    end
+    SpellCancelQueuedSpell()
 
     Bastion:Debug("Casting", self)
 


### PR DESCRIPTION
Removes the conditional check in `Spell.lua` that prevented `SpellCancelQueuedSpell()` from being called when `ThunderFocusTea` was cast.

With the new asynchronous `TFTFollowUpAPL` logic, this exception created a small window for a player's manually queued spell to execute and consume the TFT buff.

By calling `SpellCancelQueuedSpell()` for all spells unconditionally, the addon maintains full control over the spell sequence and ensures the correct follow-up spell is cast after `ThunderFocusTea`.