### PR TITLE
refactor: Use LastSpell module for recentInterrupt check

### DIFF
--- a/scripts/MW.lua
+++ b/scripts/MW.lua
@@ -1010,9 +1010,19 @@ local sootheTarget = Bastion.UnitManager:CreateCustomUnit('soothe',
     end)
 
 local function recentInterrupt()
-    if (LegSweep:GetTimeSinceLastCastAttempt() < 2) or (SpearHandStrike:GetTimeSinceLastCastAttempt() < 2) or (Paralysis:GetTimeSinceLastCastAttempt() < 2) then
+    local lastSpell = Bastion.LastSpell:Get()
+    if not lastSpell then return false end
+
+    local lastSpellID = lastSpell:GetID()
+    local isInterrupt = (lastSpellID == LegSweep:GetID()) or
+                        (lastSpellID == SpearHandStrike:GetID()) or
+                        (lastSpellID == Paralysis:GetID()) or
+                        (lastSpellID == RingOfPeace:GetID())
+
+    if isInterrupt and Bastion.LastSpell:GetTimeSince() < 2 then
         return true
     end
+
     return false
 end
 


### PR DESCRIPTION
This change refactors the `recentInterrupt()` helper function in `scripts/MW.lua`.

The previous implementation checked the `GetTimeSinceLastCastAttempt()` for three separate interrupt spells.

The new implementation uses `Bastion.LastSpell:Get()` to check if the last spell cast was one of the four off-GCD interrupts used in the APL and if it was cast within the last 2 seconds.

This change makes the logic cleaner, more robust by including all interrupt spells, and more consistent with the recent adoption of the `LastSpell` module for tracking spell history.