### PR TITLE
refactor: Use PostCast for Thunder Focus Tea follow-up

### DIFF
--- a/scripts/MW.lua
+++ b/scripts/MW.lua
@@ -17,7 +17,9 @@ local RenewingMist = SpellBook:GetSpell(115151)
 local EnvelopingMist = SpellBook:GetSpell(124682)
 local Vivify = SpellBook:GetSpell(116670)
 local RisingSunKick = SpellBook:GetSpell(107428)
-local ThunderFocusTea = SpellBook:GetSpell(116680):SetOffGCD(true)
+local ThunderFocusTea = SpellBook:GetSpell(116680):SetOffGCD(true):PostCast(function(self)
+    TFTFollowUpAPL:Execute()
+end)
 local TigerPalm = SpellBook:GetSpell(100780)
 local BlackoutKick = SpellBook:GetSpell(100784)
 local SpinningCraneKick = SpellBook:GetSpell(101546)
@@ -1738,12 +1740,6 @@ manaAPL:AddSpell(
 
 -- Module Sync
 RestoMonkModule:Sync(function()
-    local lastSpell = Bastion.LastSpell:Get()
-    if lastSpell and lastSpell:GetID() == ThunderFocusTea:GetID() and Bastion.LastSpell:GetTimeSince() < 2 then
-        TFTFollowUpAPL:Execute()
-        return
-    end
-
     JadeEmpower = false
     HasFocusTea = false
     if not Player:IsAffectingCombat() then


### PR DESCRIPTION
This refactors the logic for handling spells cast after Thunder Focus Tea (TFT).

Previously, the main `Sync` loop checked `Bastion.LastSpell` on every frame to see if TFT was the last spell cast.

The new implementation uses the `PostCast()` callback system. A `PostCast` handler has been added to the `ThunderFocusTea` spell object in `MW.lua`. This handler executes the `TFTFollowUpAPL` immediately after TFT is successfully cast.

This change makes the follow-up logic more immediate and directly ties the effect (executing the follow-up APL) to the cause (a successful TFT cast), as per the user's preference. The now-unused logic has been removed from the `Sync` function.