### PR TITLE
fix: Correctly resolve dynamic targets in TFTFollowUpAPL

### DIFF
--- a/scripts/MW.lua
+++ b/scripts/MW.lua
@@ -1091,9 +1091,11 @@ local VivifyAPL = Bastion.APL:New('vivify')
 TFTFollowUpAPL:AddSpell(
     EnvelopingMist:CastableIf(function(self)
         local target = EnvelopeLowest or DebuffTargetWithoutTFT or BusterTargetWithoutTFT or TankTarget
-        return target:IsValid() and ShouldUseEnvelopingMist(target)
-    end):SetTarget(function()
-        return EnvelopeLowest or DebuffTargetWithoutTFT or BusterTargetWithoutTFT or TankTarget
+        if target:IsValid() and ShouldUseEnvelopingMist(target) then
+            self:SetTarget(target)
+            return true
+        end
+        return false
     end)
 )
 


### PR DESCRIPTION
This commit fixes a bug that caused an "attempt to index local 'unit' (a function value)" error when the `TFTFollowUpAPL` tried to cast `Enveloping Mist`.

The root cause was that the target was defined as a function in the APL definition (`:SetTarget(function() ... end)`), but the APL framework does not execute this function to resolve the target. It passed the function itself as the unit object to the `Spell:Cast` method.

The fix refactors the `Enveloping Mist` entry in the `TFTFollowUpAPL`. The `CastableIf` function now contains the logic to determine the correct target based on game state. It then calls `self:SetTarget(target)` to store the resolved unit object on the spell before returning true. This ensures the `Spell:Cast` method receives a valid unit object.