### PR TITLE
fix(MW): Declare envelopingTarget as a local variable

### DIFF
--- a/scripts/MW.lua
+++ b/scripts/MW.lua
@@ -104,6 +104,7 @@ local isCastingCrackling = false
 local hasUsedOffGCDDefensive = {}
 local hasUsedOffGCDInterrupt = false
 local hasUsedOffGCDDps = false
+local envelopingTarget = nil
 
 -- Add this helper function near the top of the file
 


### PR DESCRIPTION
This resolves a 'attempt to index global (a nil value)' error by declaring envelopingTarget as a local variable at the top of the script. This prevents the script from crashing when the variable is accessed before being assigned a value.