### PR TITLE
Fix(Item): Pass item object to PlayerIsBusy

### DIFF
--- a/src/Casting/Casting.lua
+++ b/src/Casting/Casting.lua
@@ -13,7 +13,7 @@ function Casting:GetSpellQueueWindow()
     return (queue_window_end or 400) - world_lag - random_delay
 end
 
-function Casting:PlayerIsBusy(spellToCast)
+function Casting:PlayerIsBusy(action)
     -- Check for spell cast
     local _, _, _, _, cast_end_time, _, _, _, cast_spell_id = UnitCastingInfo("player")
     if cast_spell_id and cast_end_time and cast_end_time > 0 then
@@ -25,11 +25,11 @@ function Casting:PlayerIsBusy(spellToCast)
     local _, _, _, _, channel_end_time, _, _, channel_spell_id = UnitChannelInfo("player")
     if channel_spell_id and channel_end_time and channel_end_time > 0 then
         -- We are channeling. Check for special interrupt conditions.
-        if spellToCast then
-            if channel_spell_id == 101546 and spellToCast:InterruptsSCK() then
+        if action then
+            if channel_spell_id == 101546 and action:InterruptsSCK() then
                 return false -- Not busy, because we are allowed to interrupt.
             end
-            if channel_spell_id == 115294 and spellToCast:InterruptsManaTea() then
+            if channel_spell_id == 115294 and action:InterruptsManaTea() then
                 return false -- Not busy, because we are allowed to interrupt.
             end
         end

--- a/src/Item/Item.lua
+++ b/src/Item/Item.lua
@@ -149,7 +149,7 @@ function Item:Use(unit, condition)
         SpellStopCasting()
     end
 
-    if not self:IsOffGCD() and Casting:PlayerIsBusy() then
+    if not self:IsOffGCD() and Casting:PlayerIsBusy(self) then
         return false
     end
 
@@ -455,6 +455,22 @@ end
 
 function Item:InterruptsCast()
     return self.interruptsCast
+end
+
+function Item:InterruptsSCK()
+    local spell = self:GetSpell()
+    if spell then
+        return spell:InterruptsSCK()
+    end
+    return false
+end
+
+function Item:InterruptsManaTea()
+    local spell = self:GetSpell()
+    if spell then
+        return spell:InterruptsManaTea()
+    end
+    return false
 end
 
 -- IsMagicDispel


### PR DESCRIPTION
The PlayerIsBusy function in the Casting module can check for special interrupt conditions based on the action being performed. The call in Item.lua was not passing the item object, so these checks were not being performed for items.

This change updates the call in Item:Use to pass `self` to PlayerIsBusy. It also adds the necessary interrupt-checking methods (`InterruptsSCK`, `InterruptsManaTea`) to the Item class, which delegate to the item's associated spell.

The parameter in `Casting:PlayerIsBusy` has been renamed to `action` for clarity.